### PR TITLE
Added import io for encoding is an invalid keyword argument problem

### DIFF
--- a/export-chrome-bookmarks
+++ b/export-chrome-bookmarks
@@ -16,6 +16,7 @@ from os.path import expanduser
 from platform import system
 from re import match
 from sys import argv, stderr
+import io
 
 script_version = "2.0"
 
@@ -106,7 +107,7 @@ else:
 		exit(1)
 
 	try:
-		input_file = open(input_filename, 'r', encoding='utf-8')
+		input_file = io.open(input_filename, 'r', encoding='utf-8')
 	except IOError as e:
 		if e.errno == 2:
 			print("The bookmarks file could not be found in its default location ({}). ".format(e.filename) +


### PR DESCRIPTION
For python 2.7.12, export-chrome-bookmarks is showing 

> "TypeError: 'encoding' is an invalid keyword argument for this function". 

Resolved by adding `import io`
